### PR TITLE
fix(scripts): include the lib directory in the output zip

### DIFF
--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mkdir -p dist
 npm ci --prod
-zip dist/mezmo-cloudwatch.zip -r node_modules/ config.js index.js package.json
+zip dist/mezmo-cloudwatch.zip -r node_modules/ lib/ config.js index.js package.json


### PR DESCRIPTION
in the last release additional files were included in the repository that are necessary for the application to function, but they were not included in the build script. The lib directory was excluded from the final zip output which was preventing the application from running correctly

Fixes: #12